### PR TITLE
Update PostgreSQL volume mapping to /var/lib/postgresql

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql
     networks:
       - app-network
 

--- a/install.sh
+++ b/install.sh
@@ -476,7 +476,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASS}
       POSTGRES_DB: 3dp_manager
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d 3dp_manager"]
       interval: 5s
@@ -587,7 +587,7 @@ services:
       POSTGRES_PASSWORD: ${DB_PASS}
       POSTGRES_DB: 3dp_manager
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U admin -d 3dp_manager"]
       interval: 5s


### PR DESCRIPTION
Changed the PostgreSQL volume mapping in `install.sh` and `docker-compose.yml` from `/var/lib/postgresql/data` to `/var/lib/postgresql`. This ensures that the entire PostgreSQL home directory is persisted in the volume as requested by the user. Verified that all occurrences in the codebase were updated and that backend tests pass with this configuration.

---
*PR created automatically by Jules for task [5564566905280484491](https://jules.google.com/task/5564566905280484491) started by @denpiligrim*