### PR TITLE
Removed insecure from inbounds builder

### DIFF
--- a/server/src/inbounds/inbound-builder.service.ts
+++ b/server/src/inbounds/inbound-builder.service.ts
@@ -469,7 +469,7 @@ export class InboundBuilderService {
             content: '',
             dir: '',
             headers: {},
-            insecure: true,
+            insecure: false,
             rewriteHost: false,
             statusCode: 0,
             type: 'proxy',
@@ -703,7 +703,7 @@ export class InboundBuilderService {
     const auth = settings.clients?.[0]?.auth || settings.clients?.[0]?.password || password;
     const finalmask = stream.finalmask?.udp?.[0];
     const params = new URLSearchParams();
-    params.set('insecure', '1');
+    params.set('insecure', '0');
     params.set('security', 'tls');
     params.set('fp', 'chrome');
     params.set('alpn', 'h3');
@@ -769,7 +769,7 @@ export class InboundBuilderService {
     }
 
     const params = new URLSearchParams();
-    params.set('insecure', '1');
+    params.set('insecure', '0');
     params.set('security', 'tls');
     params.set('fp', 'chrome');
     params.set('alpn', 'h3');


### PR DESCRIPTION
В happ на macOS была ошибка, из-за которой не работали соединения Hysteria 
<img width="960" height="1588" alt="2026-06-08_23-27" src="https://github.com/user-attachments/assets/fe6beb46-f738-4c75-936e-fef247df701c" />
